### PR TITLE
Add storage option to sequential workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ allows for infinite nesting, as the workflow itself can be a component of anothe
 **Sequential** is a workflow that runs all of its steps/commands in a predefined order/sequence. \
 Every step can be configured to stop the workflow on failure(default behaviour) or let it process the rest of the
 steps. \
-It has the ability to retry at the step level, with a configured number of attempts and delay.
+It has the ability to retry at the step level, with a configured number of attempts and delay. \
+<u>Optionally</u> you can pass a storage option to the constructor to be able to replay the same request without the \
+fear of duplicating successful steps. This becomes handy on microservice arch. when is needed to replay an event.
+
 
 **Pipe** is a workflow that runs all of its steps/commands in a predefined order/sequence. \
 Except for the first step, which receives the initial request as input, every subsequent step receives as an input, the
@@ -65,7 +68,7 @@ func main() {
 		{Step: &step2},
 		{Step: &step3},
 	}
-	wf := workflow.NewSequential("ETL", wfConfig, nil)
+	wf := workflow.NewSequential("ETL", wfConfig)
 	req := request{id: "1"}
 	err := wf.Execute(context.Background(), &req)
 	if err != nil {
@@ -162,7 +165,7 @@ func main() {
 		{Step: &step3, ContinueWorkflowOnError: true},
 		{Step: &step4, ContinueWorkflowOnError: true},
 	}
-	wf := workflow.NewSequential("ETL", wfConfig, nil)
+	wf := workflow.NewSequential("ETL", wfConfig)
 	req := event{name: "client created"}
 	err := wf.Execute(context.Background(), req)
 	if err != nil {
@@ -335,6 +338,13 @@ func (s *removeDots) Execute(ctx context.Context, req string) (string, error) {
 }
 
 ```
+</details>
+
+<details>
+<summary>example 4: Use Sequential workflow with storage to be able to store each step </summary> 
+Each step result is stored and if the same request gets replayed the workflow will execute only previous failed steps.
+
+See: `storage_test.go`
 </details>
 
 [doc-img]: https://pkg.go.dev/badge/silviutanasa/workflow

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,6 @@
+**Version 1.0.1 - 28/02/2024**
+- removed `log` param from `Sequential` constructor function. Instead, introduced decorator pattern and 
+logger will be passed via option function, eg. `New(..., WithLogger(logger))`
+- introduced Storage option to be able to store step result. This will become handy when you're dealing with
+microservice arch. and you need to replay an event/message. In case of an event reply, this functionality allows the 
+workflow to skip successful steps and only execute previously failed ones.

--- a/example_test.go
+++ b/example_test.go
@@ -3,9 +3,8 @@ package workflow_test
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	"github.com/silviutanasa/workflow"
+	"strings"
 )
 
 func ExampleSequential_Execute() {
@@ -14,7 +13,7 @@ func ExampleSequential_Execute() {
 		{Step: &sequentialStepAbstract{name: "get-raw-data-from-db"}},
 		{Step: &sequentialStepAbstract{name: "transform-raw-data-into-models"}},
 	}
-	extractDataWorkflow := workflow.NewSequential("extract-data", stepsCfgEmb, nil)
+	extractDataWorkflow := workflow.NewSequential("extract-data", stepsCfgEmb)
 
 	stepsCfg := []workflow.SequentialStepConfig[any]{
 		{Step: extractDataWorkflow},
@@ -22,7 +21,7 @@ func ExampleSequential_Execute() {
 		{Step: &sequentialStepAbstract{name: "load-data"}},
 	}
 
-	wf := workflow.NewSequential("ETL", stepsCfg, nil)
+	wf := workflow.NewSequential("ETL", stepsCfg)
 	wf.Execute(context.TODO(), nil)
 	// Output:
 	//running: get-raw-data-from-db

--- a/sequential.go
+++ b/sequential.go
@@ -3,9 +3,13 @@ package workflow
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 )
+
+// ErrMissingCorrelationID is thrown when the storage option is provided but there is no step correlation id.
+var ErrMissingCorrelationID = errors.New("missing correlation ID")
 
 // SequentialStep describes a step of execution.
 type SequentialStep[T any] interface {
@@ -26,24 +30,49 @@ type SequentialStepConfig[T any] struct {
 
 // Sequential is a workflow that runs its steps in a predefined sequence(the order of the []SequentialStepConfig).
 type Sequential[T any] struct {
+	// this ID is only used for storage and usually is the eventID from request object.
+	// in this way when the event is replayed the `workflow` will be able to skip previous successful steps.
+	correlationID *string
+
 	name        string
 	stepsConfig []SequentialStepConfig[T] // the workflow runs the steps following the slice order
 	log         Logger                    // the internal logger is a no op if nil is provided
+	store       Storage
 }
 
-// NewSequential is the workflow constructor.
-func NewSequential[T any](name string, stepsCfg []SequentialStepConfig[T], log Logger) *Sequential[T] {
-	if log == nil {
-		log = noOpLogger{}
-	}
+// SequentialOption is an alias function used to apply various configurations.
+type SequentialOption func(s *Sequential[any])
 
-	s := Sequential[T]{
+// NewSequential is the workflow constructor.
+func NewSequential[T any](name string, stepsCfg []SequentialStepConfig[T], opts ...SequentialOption) *Sequential[T] {
+	s := &Sequential[T]{
 		name:        name,
 		stepsConfig: stepsCfg,
-		log:         log,
 	}
 
-	return &s
+	for _, opt := range opts {
+		opt((interface{})(s).(*Sequential[any]))
+	}
+
+	return s
+}
+
+func WithLogger(log Logger) SequentialOption {
+	return func(s *Sequential[any]) {
+		s.log = log
+	}
+}
+
+func WithStorage(st Storage) SequentialOption {
+	return func(s *Sequential[any]) {
+		s.store = st
+	}
+}
+
+func WithCorrelationID(id string) SequentialOption {
+	return func(s *Sequential[any]) {
+		s.correlationID = &id
+	}
 }
 
 // Name returns the name of the workflow.
@@ -57,12 +86,20 @@ func (s *Sequential[T]) Name() string {
 // In case a SequentialStepConfig.Step fails, the workflow checks for the SequentialStepConfig.ContinueWorkflowOnError flag, and stops processing
 // the remaining steps if the value is true.
 func (s *Sequential[T]) Execute(ctx context.Context, req T) error {
-	s.log.Info(concatStr("[START] executing workflow: ", s.name))
-	defer func() { s.log.Info(concatStr("[DONE] executing workflow: ", s.name)) }()
+	s.print(concatStr("[START] executing workflow: ", s.name), infoLevel)
+	defer func() { s.print(concatStr("[DONE] executing workflow: ", s.name), infoLevel) }()
 
-	var errs []error
-	var err error
+	var (
+		errs []error
+		err  error
+	)
+
 	for _, stepConfig := range s.stepsConfig {
+		if s.skipStep(ctx, stepConfig.Step.Name()) {
+			s.print(concatStr("step: ", stepConfig.Step.Name(), " is already processed, skipping"), infoLevel)
+			continue
+		}
+
 		err = s.executeStep(ctx, stepConfig, req)
 		if err != nil {
 			// this prevents extra allocations, by creating the slice only once, and with enough capacity.
@@ -72,13 +109,11 @@ func (s *Sequential[T]) Execute(ctx context.Context, req T) error {
 			errs = append(errs, err)
 
 			if stepConfig.ContinueWorkflowOnError {
-				s.log.Info(
-					concatStr(
-						"the step name: ",
-						stepConfig.Step.Name(),
-						", is configured not to stop the workflow on error, so the following stepsConfig(if any) will still run",
-					),
-				)
+				s.print(concatStr(
+					"the step name: ",
+					stepConfig.Step.Name(),
+					", is configured not to stop the workflow on error, so the following stepsConfig(if any) will still run",
+				), infoLevel)
 
 				continue
 			}
@@ -95,46 +130,116 @@ func (s *Sequential[T]) Execute(ctx context.Context, req T) error {
 		return errors.Join(errs...)
 	}
 
-	return nil
+	// if everything was ok, then cleanup storage
+	return s.clearDB(ctx, s.correlationID)
 }
 
 // executeStep processes a single SequentialStep by passing it the ctx and the req.
 // It retries the SequentialStep if it implements the RetryDecider interface, and uses the max attempts and the attempt delay provided
 // by the SequentialStepConfig.RetryConfigProvider() if it's not nil. If the SequentialStepConfig.RetryConfigProvider() is nil, there is no retry.
 func (s *Sequential[T]) executeStep(ctx context.Context, stepCfg SequentialStepConfig[T], req T) error {
+	var (
+		maxAttempts  uint
+		attemptDelay time.Duration
+		attempt      int
+		err          error
+	)
+
 	step := stepCfg.Step
 	stepName := step.Name()
 
-	var maxAttempts uint
-	var attemptDelay time.Duration
 	if stepCfg.RetryConfigProvider != nil {
 		maxAttempts, attemptDelay = stepCfg.RetryConfigProvider()
 	}
 
-	var attempt int
-	var err error
 	for attempt = 0; attempt <= int(maxAttempts); attempt++ {
 		// if the attempt is greater than 0, then it's a retry
 		if attempt > 0 {
-			s.log.Info(
+			s.print(
 				concatStr("step: ", stepName, " is configured to retry", ", retry attempt count: ", strconv.Itoa(attempt)),
+				infoLevel,
 			)
 			// allow some waiting time before trying again
-			s.log.Info(concatStr("waiting for: ", strconv.FormatInt(attemptDelay.Milliseconds(), 10), "ms before retry attempt"))
+			s.print(concatStr("waiting for: ", strconv.FormatInt(attemptDelay.Milliseconds(), 10), "ms before retry attempt"), infoLevel)
 			time.Sleep(attemptDelay)
 		}
+
 		err = step.Execute(ctx, req)
 		if err == nil {
-			s.log.Info(concatStr(succeed, " executing step: ", stepName))
+			s.print(concatStr(succeed, " executing step: ", stepName), infoLevel)
 
 			break
 		}
-		s.log.Error(concatStr(failed, " executing step: ", stepName, ", err: ", err.Error()))
+
+		s.print(concatStr(failed, " executing step: ", stepName, ", err: ", err.Error()), errorLevel)
 		// only the ones implementing the RetryDecider, with CanRetry() returning true, can run more than once
 		if stepR, ok := step.(RetryDecider); !ok || (ok && !stepR.CanRetry()) {
 			break
 		}
 	}
 
+	dbErr := s.storeStepResult(ctx, stepName, err)
+	if dbErr != nil {
+		err = fmt.Errorf("error storing step execution result: %q", err)
+	}
+
 	return err
+}
+
+func (s *Sequential[T]) print(msg string, level int) {
+	if s.log == nil {
+		return
+	}
+
+	switch level {
+	case 1:
+		s.log.Info(msg)
+	case 2:
+		s.log.Error(msg)
+	}
+}
+
+func (s *Sequential[T]) skipStep(ctx context.Context, stepName string) bool {
+	if s.store == nil {
+		return false
+	}
+
+	if s.correlationID == nil {
+		return false
+	}
+
+	sts, err := s.store.Get(ctx, stepName, *s.correlationID)
+	if err != nil {
+		s.print(err.Error(), errorLevel)
+		return false
+	}
+
+	return sts == SUCCESS
+}
+
+func (s *Sequential[T]) storeStepResult(ctx context.Context, stepName string, err error) error {
+	if s.store == nil {
+		return nil
+	}
+
+	if s.correlationID == nil {
+		return fmt.Errorf("cannot store step result in DB: %q", ErrMissingCorrelationID)
+	}
+
+	var output string
+	sts := SUCCESS
+	if err != nil {
+		sts = FAILED
+		output = err.Error()
+	}
+
+	return s.store.Save(ctx, stepName, *s.correlationID, sts, &output)
+}
+
+func (s *Sequential[T]) clearDB(ctx context.Context, id *string) error {
+	if s.store == nil || id == nil {
+		return nil
+	}
+
+	return s.store.Clear(ctx, *id)
 }

--- a/storage.go
+++ b/storage.go
@@ -1,0 +1,17 @@
+package workflow
+
+import "context"
+
+type StepStatus string
+
+const (
+	FAILED  StepStatus = "FAILED"
+	SUCCESS StepStatus = "SUCCESS"
+)
+
+// Storage describes the functionality for storing step execution result.
+type Storage interface {
+	Save(ctx context.Context, stepName, correlationID string, status StepStatus, output *string) error
+	Get(ctx context.Context, stepName, correlationID string) (StepStatus, error)
+	Clear(ctx context.Context, correlationID string) error
+}

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,0 +1,150 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Scenario when the same request is executed twice but only the previously failed steps will run.
+// Iteration 1:
+// correlation_id_1:
+//
+//	step1: success
+//	step2: failed
+//
+// -------------
+// Iteration 2:
+// correlation_id_1: --same correlation id
+//
+//	step1: skipped
+//	step2: success
+func Test_Sequential_With_Storage(t *testing.T) {
+	anyErr := errors.New("any-error")
+
+	successStep1 := SequentialStepConfig[any]{Step: newStepSuccessful("step1")}
+	failedStep2 := SequentialStepConfig[any]{Step: newStepFailedNonRetryable("step2", anyErr)}
+	successStep2 := SequentialStepConfig[any]{Step: newStepSuccessful("step2")}
+
+	corID := "abcd-1234-defg-5678"
+	storage := NewInMemoryRepository()
+
+	c := NewSequential(
+		"some-workflow",
+		[]SequentialStepConfig[any]{successStep1, failedStep2},
+		WithStorage(storage),
+		WithCorrelationID(corID),
+	)
+
+	// 1) Step 2 will fail and the workflow will exit with error.
+	actualOutput := c.Execute(context.TODO(), nil)
+	expectedOutput := anyErr
+	if !errors.Is(actualOutput, expectedOutput) {
+		t.Errorf("the workflow error does not wrap the inner errors: \n expected = %#v, \n actual = %#v", expectedOutput, actualOutput)
+		t.FailNow()
+	}
+
+	// 2) The workflow will get reinitialized with the same correlationID. Because the previous workflow steps execution is stored in db,
+	// only the step(s) that failed previously will get executed.
+	c2 := NewSequential(
+		"some-workflow",
+		[]SequentialStepConfig[any]{successStep1, successStep2}, // we mark step2 as successful now
+		WithStorage(storage),
+		WithCorrelationID(corID),
+	)
+
+	gotErr := c2.Execute(context.TODO(), nil)
+	if gotErr != nil {
+		t.Errorf("the workflow returned error: %#v", gotErr)
+		t.FailNow()
+	}
+
+	// step1 has been passed twice to the workflow, but on the second run it should be skipped.
+	successfulStepConverted := (interface{})(successStep1.Step).(*stepMock)
+	if successfulStepConverted.invocationCount != 1 {
+		t.Errorf("step %s should be processed only once, actual count %d", successStep1.Step.Name(), successfulStepConverted.invocationCount)
+		t.FailNow()
+	}
+}
+
+// --------------------------
+// In memory storage mock.
+
+type repositoryStep struct {
+	name   string
+	status string
+	output *string
+}
+
+type Repository struct {
+	steps      map[string][]repositoryStep
+	sync.Mutex // safeguard map with locking mechanism.
+}
+
+func NewInMemoryRepository() *Repository {
+	return &Repository{
+		steps: make(map[string][]repositoryStep),
+	}
+}
+
+func (r *Repository) Save(ctx context.Context, stepName, correlationID string, status StepStatus, output *string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	s := repositoryStep{
+		name:   clean([]byte(stepName)), // perform sanitization
+		status: string(status),
+		output: output,
+	}
+	r.steps[correlationID] = append(r.steps[correlationID], s)
+
+	return nil
+}
+
+func (r *Repository) Get(ctx context.Context, stepName, correlationID string) (StepStatus, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	if _, ok := r.steps[correlationID]; !ok {
+		return "", fmt.Errorf("there are no steps stored for correlationID: %s", correlationID)
+	}
+
+	cleanStepName := clean([]byte(stepName))
+	for _, s := range r.steps[correlationID] {
+		if s.name == cleanStepName {
+			return StepStatus(s.status), nil
+		}
+	}
+
+	return "", fmt.Errorf("step %s not found", stepName)
+}
+
+func (r *Repository) Clear(ctx context.Context, correlationID string) error {
+	r.Lock()
+	defer r.Unlock()
+
+	r.steps[correlationID] = []repositoryStep{}
+	return nil
+}
+
+// clean will remove all non-alphanumeric characters, except space and underscore then replace space with underscore.
+func clean(s []byte) string {
+	j := 0
+	for _, b := range s {
+		if ('a' <= b && b <= 'z') ||
+			('A' <= b && b <= 'Z') ||
+			('0' <= b && b <= '9') ||
+			// detect consecutive spaces and append only one space instead
+			(b == ' ' && (j != 0 && s[j-1] != ' ')) ||
+			// detect consecutive underscore and append only one underscore instead
+			(b == '_' && (j != 0 && s[j-1] != '_')) {
+			s[j] = b
+			j++
+		}
+	}
+
+	return strings.ReplaceAll(string(s[:j]), " ", "_")
+}

--- a/workflow.go
+++ b/workflow.go
@@ -9,6 +9,10 @@ import (
 const (
 	succeed = "\u2713"
 	failed  = "\u2717"
+
+	// used for logging
+	infoLevel  = 1
+	errorLevel = 2
 )
 
 // bufPool is used by the internal logging system, to compute the string messages.


### PR DESCRIPTION
- removed `log` param from `Sequential` constructor function. Instead, introduced decorator pattern and 
logger will be passed via option function, eg. `New(..., WithLogger(logger), WithStorage(storage))`
- introduced Storage option to be able to store step result. This will become handy when you're dealing with
microservice arch. and you need to replay an event/message. In case of an event reply, this functionality allows the 
workflow to skip successful steps and only execute previously failed ones.